### PR TITLE
Move imports on lines with other, resting, imports

### DIFF
--- a/src/mvdef/core/agenda.py
+++ b/src/mvdef/core/agenda.py
@@ -337,6 +337,7 @@ class Agenda:
                 if imp is not departure.bound
             ]
             if resting_imports:
+                breakpoint()
                 raise NotImplementedError("Imports staying and going on same line")
         copped = [
             Arrival(name=n.name, rng=self.def_rng(n.name)) for n in self.unique_cops


### PR DESCRIPTION
**Purpose**

To support moving imports from lines which they are currently on.

**Use case**

Consider this file

```py
$ cat bar.py 
from pathlib import Path

from .foo import FOO, read

p = Path()

def bar(path):
    return read(path)

if FOO:
    bar(path=p)
```

If you do this now you get

```sh
$ mvdef -d -m=bar bar.py dst.py
Traceback (most recent call last):
  File "/home/louis/miniconda3/bin/mvdef", line 8, in <module>
    sys.exit(cli_move())
  File "/home/louis/miniconda3/lib/python3.10/site-packages/mvdef/cli.py", line 57, in cli_move
    return cli(MvCls=MvDef, *args, **kwargs)
  File "/home/louis/miniconda3/lib/python3.10/site-packages/mvdef/cli.py", line 43, in cli
    diffs = mover.diffs(print_out=True)
  File "/home/louis/miniconda3/lib/python3.10/site-packages/mvdef/transfer/move.py", line 98, in diffs
    src_unidiff = self.src_diff.unidiff()
  File "/home/louis/miniconda3/lib/python3.10/site-packages/mvdef/core/diff/diff.py", line 38, in unidiff
    return self.agenda.unidiff(target_file=self.target_file, is_src=self.is_src)
  File "/home/louis/miniconda3/lib/python3.10/site-packages/mvdef/core/agenda.py", line 267, in unidiff
    new = self.simulate(input_text=old)
  File "/home/louis/miniconda3/lib/python3.10/site-packages/mvdef/core/agenda.py", line 479, in simulate
    return self.resimulate(
  File "/home/louis/miniconda3/lib/python3.10/site-packages/mvdef/core/agenda.py", line 450, in resimulate
    filtered = self.apply(
  File "/home/louis/miniconda3/lib/python3.10/site-packages/mvdef/core/agenda.py", line 340, in apply
    raise NotImplementedError("Imports staying and going on same line")
NotImplementedError: Imports staying and going on same line
```

Here is the beginning of the apply method:

```py
    def apply(
        self,
        input_text: str,
        *,
        imports_in: list[ArrivingImport],
        imports_out: list[DepartingImport],
        recheck: Checker | None = None,
    ) -> str:
        if imports_out:
            resting_imports = [
                imp
                for departure in imports_out
                for imp in self.original_ref.imports
                if imp.source.lineno == departure.lineno
                if imp is not departure.bound
            ]
            if resting_imports:
                raise NotImplementedError("Imports staying and going on same line")
```